### PR TITLE
NiPoPoWs links

### DIFF
--- a/content/02-learn/06-sagano-mantis-testnet.mdx
+++ b/content/02-learn/06-sagano-mantis-testnet.mdx
@@ -21,5 +21,5 @@ Instructions on how to use them can be found in the [How-To section](#/how-tos/h
 Future testnet releases look to support the evolution of Ethererum Classic, protocol improvements to be potentially explored and proposed are:
   - [Sha-3-256](https://ecips.ethereumclassic.org/ECIPs/ecip-1049)
   - [KEVM](https://runtimeverification.com/formal-design-and-modeling/#virtual-machines-kevm-iele) + [Firefly](https://runtimeverification.com/firefly/)
-  - [NiPoPoWs](https://eprint.iacr.org/2017/963.pdf https://nipopows.com/)
+  - [NiPoPoWs](https://nipopows.com/) ([publication](https://eprint.iacr.org/2017/963.pdf))
   - [Coded Merkle Trees](https://eprint.iacr.org/2019/1139.pdf)


### PR DESCRIPTION
This change will make the page looks like:
[NiPoPoWs](https://nipopows.com/) ([publication](https://eprint.iacr.org/2017/963.pdf))

Alternatively one could remove one link completely.

But the current version seems like an  error:
[NiPoPoWs](https://eprint.iacr.org/2017/963.pdf https://nipopows.com/)