### PR TITLE
small fix in 00-how-to-use-mantis.mdx

### DIFF
--- a/content/03-how-tos/00-how-to-use-mantis.mdx
+++ b/content/03-how-tos/00-how-to-use-mantis.mdx
@@ -5,7 +5,7 @@ metaTitle: How to use Mantis
 
 ## Binaries
 
-Once [Mantis is installed](../install), you have two options to launch Mantis; using the main `mantis` binary or using the `mantis-launcher` helper script. Both are located in the `bin` folder.
+Once [Mantis is installed](../install), you have two options to launch Mantis: using the main `mantis` binary or using the `mantis-launcher` helper script. Both are located in the `bin` folder.
 
 ```
 cd mantis
@@ -37,7 +37,7 @@ cd <mantis-install-folder>
 
 ## Mantis Folders
 
-The Mantis client creates its main folder in your home folder, inside a its respective network name folder.
+The Mantis client creates its main folder in your home folder, inside its respective network name folder.
   
 * Linux: `/home/user/.mantis/<network-name>`
 * macOS: `/User/user/.mantis/<network-name>`


### PR DESCRIPTION
small types:
* replace `;` by `:`
* remove unnecessary `a` 