### PR TITLE
fix type Kademlia in  03-how-to-configure-the-client.mdx

### DIFF
--- a/content/03-how-tos/03-how-to-configure-the-client.mdx
+++ b/content/03-how-tos/03-how-to-configure-the-client.mdx
@@ -61,7 +61,7 @@ You can also change this setting by setting a Dkey parameter at runtime:
 
 ## Discovery
 
-The discovery function is active by default. The network is queried for additional potential nodes using a partial implementation of the kadelmia discovery protocol.
+The discovery function is active by default. The network is queried for additional potential nodes using a partial implementation of the Kademlia discovery protocol.
 
 ### Conf file
 


### PR DESCRIPTION
Rename `kadelmia` to `Kademlia`
(Upper case because this is how wiki is doing: https://en.wikipedia.org/wiki/Kademlia)