### PR TITLE
Point installation instructions to GitHub latest releases page.

### DIFF
--- a/content/01-install/02a-install-wallet-windows.mdx
+++ b/content/01-install/02a-install-wallet-windows.mdx
@@ -24,7 +24,7 @@ These are the prerequisites for installing Mantis wallet:
 
 To install Mantis wallet, follow these steps:
 
-1. Choose and download the Windows 64 bit installer from the [wallet release page](https://github.com/input-output-hk/mantis-wallet/releases/latest).
+1. Choose and download the Windows 64 bit installer from the [wallet release page](https://github.com/input-output-hk/mantis-wallet/releases/latest). the Windows installer is the one with the .exe extension.
 2. Note the checksum.
 > Remember to run checksum verification on your downloads. Refer to [this section](/how-tos/how-check-hash-windows) for instructions.
 

--- a/content/01-install/02a-install-wallet-windows.mdx
+++ b/content/01-install/02a-install-wallet-windows.mdx
@@ -24,8 +24,7 @@ These are the prerequisites for installing Mantis wallet:
 
 To install Mantis wallet, follow these steps:
 
-1. Choose and download the Windows 64 bit installer from the [wallet quick-start page](/first-steps/wallet-quickstart):
-![Windows installer](../images/2-Download-Installer.png)
+1. Choose and download the Windows 64 bit installer from the [wallet release page](https://github.com/input-output-hk/mantis-wallet/releases/latest).
 2. Note the checksum.
 > Remember to run checksum verification on your downloads. Refer to [this section](/how-tos/how-check-hash-windows) for instructions.
 

--- a/content/01-install/02b-install-wallet-linux.mdx
+++ b/content/01-install/02b-install-wallet-linux.mdx
@@ -34,7 +34,7 @@ Mantis-Wallet-<version>.AppImage
 2. Note the checksum.
 > Remember to run checksum verification on your downloads. Refer to [this section](/how-tos/how-check-hash-linux) for instructions.
 
-3. For more information, see [where to place the AppImage file](https://docs.appimage.org/user-guide/faq.html#question-where-do-i-store-my-appimages).
+3. For more information, see [where to place the AppImage file](https://docs.appimage.org/user-guide/faq.html#question-where-do-i-store-my-appimages). The Linux installer is the one with the .AppImage extension.
 
 4. Mark the Appimage file executable:
 ![Linux screenshot](../images/2c-Linux-Mark-Executable.png)

--- a/content/01-install/02b-install-wallet-linux.mdx
+++ b/content/01-install/02b-install-wallet-linux.mdx
@@ -25,10 +25,8 @@ These are the prerequisites for installing Mantis wallet:
 
 To install Mantis wallet, follow these steps:
 
-1. Download the wallet binary from the [wallet quick-start page](/first-steps/wallet-quickstart):
-![Mantis wallet page](../images/1-Download.png).
-Choose and download the Linux installer from the wallet quick-start page:
-![Linux Installer](../images/2b-Download-Installer.png)
+1. Download the wallet binary from the [wallet releases page](https://github.com/input-output-hk/mantis-wallet/releases/latest).
+Choose and download the Linux installer from the wallet releases page.
 
 ```
 Mantis-Wallet-<version>.AppImage

--- a/content/01-install/02c-install-wallet-Mac.mdx
+++ b/content/01-install/02c-install-wallet-Mac.mdx
@@ -24,8 +24,7 @@ These are the prerequisites for installing Mantis Wallet:
 
 To install Mantis wallet, follow these steps:
 
-1. Choose and download the Apple Mac installer from the [wallet quick-start page](/first-steps/wallet-quickstart):
-![Apple Mac Installer](../images/2c-Download-Installer.png)
+1. Choose and download the Apple Mac installer from the [wallet releases page](https://github.com/input-output-hk/mantis-wallet/releases/latest)
 Note the checksum.
 ```
 Mantis-Wallet-<version>.dmg

--- a/content/01-install/02c-install-wallet-Mac.mdx
+++ b/content/01-install/02c-install-wallet-Mac.mdx
@@ -24,7 +24,8 @@ These are the prerequisites for installing Mantis Wallet:
 
 To install Mantis wallet, follow these steps:
 
-1. Choose and download the Apple Mac installer from the [wallet releases page](https://github.com/input-output-hk/mantis-wallet/releases/latest)
+1. Choose and download the Apple Mac installer from the [wallet releases page](https://github.com/input-output-hk/mantis-wallet/releases/latest). 
+The Apple installer is the one with the .dmg extension.
 Note the checksum.
 ```
 Mantis-Wallet-<version>.dmg


### PR DESCRIPTION
With release 0.2.0 of the wallet, we identified that the installation instructions must point to the latest releases page in GitHub.